### PR TITLE
Need to update lanterna Dependency for TerminalPalette

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://sjl.bitbucket.org/clojure-lanterna/"
   :license {:name "LGPL"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [com.googlecode.lanterna/lanterna "2.0.3"]]
+                 [com.googlecode.lanterna/lanterna "2.1.1"]]
   :java-source-paths ["./java"]
   ; :repositories {"sonatype-snapshots" "https://oss.sonatype.org/content/repositories/snapshots"}
   )

--- a/test/lanterna/test/test_dependencies.clj
+++ b/test/lanterna/test/test_dependencies.clj
@@ -1,0 +1,6 @@
+(ns lanterna.test.test-dependencies
+  (:use [lanterna.constants])
+  (:use [clojure.test]))
+
+(deftest tautology
+   (is true))


### PR DESCRIPTION
- constants will not compile with current version of lanterna

Exception in thread "main" java.lang.ClassNotFoundException:
com.googlecode.lanterna.terminal.swing.TerminalPalette
  at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
  at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
  at java.security.AccessController.doPrivileged(Native Method)
  at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
  at clojure.lang.DynamicClassLoader.findClass(DynamicClassLoader.java:61)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:423)
  at java.lang.ClassLoader.loadClass(ClassLoader.java:356)
  at java.lang.Class.forName0(Native Method)
  at java.lang.Class.forName(Class.java:186)
  at lanterna.constants$eval39$loading__4784__auto____40.invoke(constants.clj:1)
