### PR TITLE
Upgrade Lanterna from 2.1.1 to 2.1.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject clojure-lanterna "0.9.3"
+(defproject clojure-lanterna "0.9.4"
   :description "A Clojure wrapper around the Lanterna terminal output library."
   :url "http://sjl.bitbucket.org/clojure-lanterna/"
   :license {:name "LGPL"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [com.googlecode.lanterna/lanterna "2.1.1"]]
+                 [com.googlecode.lanterna/lanterna "2.1.5"]]
   :java-source-paths ["./java"]
   ; :repositories {"sonatype-snapshots" "https://oss.sonatype.org/content/repositories/snapshots"}
   )


### PR DESCRIPTION
During the course of using clojure-lanterna I ran into a nasty bug in
Lanterna where `clear`ing my screen left behind white background
artifacts which persisted across multiple subsequent `redraw`s. Upgrading
Lanterna to 2.1.5 corrected this issue for me.

This pull-request upgrades the Lanterna dependency to 2.1.5 and bumps
the project's version to 0.9.4.
