### PR TITLE
updated lanterna to 2.1.7 and clojure-lanterna to 0.9.5.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject clojure-lanterna "0.9.4"
+(defproject clojure-lanterna "0.9.5"
   :description "A Clojure wrapper around the Lanterna terminal output library."
   :url "http://sjl.bitbucket.org/clojure-lanterna/"
   :license {:name "LGPL"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [com.googlecode.lanterna/lanterna "2.1.5"]]
+                 [com.googlecode.lanterna/lanterna "2.1.7"]]
   :java-source-paths ["./java"]
   ; :repositories {"sonatype-snapshots" "https://oss.sonatype.org/content/repositories/snapshots"}
   )


### PR DESCRIPTION
There's a weird bug that causes the dimensions of gnome terminal to always be 80x20. Upgrading lanterna fixes it.