### PR TITLE
Added terminal colours and updated version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,10 @@
-(defproject clojure-lanterna "0.9.5"
+(defproject org.clojars.folcon/clojure-lanterna "0.9.5-SNAPSHOT"
   :description "A Clojure wrapper around the Lanterna terminal output library."
   :url "http://sjl.bitbucket.org/clojure-lanterna/"
   :license {:name "LGPL"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [com.googlecode.lanterna/lanterna "2.1.7"]]
+                 ;[com.googlecode.lanterna/lanterna "2.1.7"]
+                 [org.clojars.folcon/lanterna "3.0.0-SNAPSHOT"]]
   :java-source-paths ["./java"]
   ; :repositories {"sonatype-snapshots" "https://oss.sonatype.org/content/repositories/snapshots"}
   )

--- a/src/lanterna/constants.clj
+++ b/src/lanterna/constants.clj
@@ -3,6 +3,7 @@
            com.googlecode.lanterna.TerminalFacade
            com.googlecode.lanterna.screen.Screen
            com.googlecode.lanterna.terminal.Terminal
+           com.googlecode.lanterna.terminal.TextColor
            com.googlecode.lanterna.screen.ScreenCharacterStyle
            com.googlecode.lanterna.terminal.swing.TerminalPalette
            com.googlecode.lanterna.input.Key))
@@ -11,15 +12,15 @@
 (def charsets {:utf-8 (Charset/forName "UTF-8")})
 
 (def colors
-  {:black   com.googlecode.lanterna.terminal.Terminal$Color/BLACK
-   :white   com.googlecode.lanterna.terminal.Terminal$Color/WHITE
-   :red     com.googlecode.lanterna.terminal.Terminal$Color/RED
-   :green   com.googlecode.lanterna.terminal.Terminal$Color/GREEN
-   :blue    com.googlecode.lanterna.terminal.Terminal$Color/BLUE
-   :cyan    com.googlecode.lanterna.terminal.Terminal$Color/CYAN
-   :magenta com.googlecode.lanterna.terminal.Terminal$Color/MAGENTA
-   :yellow  com.googlecode.lanterna.terminal.Terminal$Color/YELLOW
-   :default com.googlecode.lanterna.terminal.Terminal$Color/DEFAULT})
+  {:black   com.googlecode.lanterna.terminal.TextColor$ANSI/BLACK
+   :white   com.googlecode.lanterna.terminal.TextColor$ANSI/WHITE
+   :red     com.googlecode.lanterna.terminal.TextColor$ANSI/RED
+   :green   com.googlecode.lanterna.terminal.TextColor$ANSI/GREEN
+   :blue    com.googlecode.lanterna.terminal.TextColor$ANSI/BLUE
+   :cyan    com.googlecode.lanterna.terminal.TextColor$ANSI/CYAN
+   :magenta com.googlecode.lanterna.terminal.TextColor$ANSI/MAGENTA
+   :yellow  com.googlecode.lanterna.terminal.TextColor$ANSI/YELLOW
+   :default com.googlecode.lanterna.terminal.TextColor$ANSI/DEFAULT})
 
 (def styles
   {:bold ScreenCharacterStyle/Bold

--- a/src/lanterna/screen.clj
+++ b/src/lanterna/screen.clj
@@ -1,6 +1,7 @@
 (ns lanterna.screen
   (:import com.googlecode.lanterna.screen.Screen
-           com.googlecode.lanterna.terminal.Terminal)
+           com.googlecode.lanterna.terminal.Terminal
+           com.googlecode.lanterna.terminal.TextColor)
   (:use [lanterna.common :only [parse-key block-on]])
   (:require [lanterna.constants :as c]
             [lanterna.terminal :as t]))
@@ -142,6 +143,10 @@
   [^Screen screen x y]
   (.setCursorPosition screen x y))
 
+(defn get-color [color]
+  (cond (keyword? color) ^com.googlecode.lanterna.terminal.TextColor$ANSI (c/colors color)
+        (vector? color) (let [[r g b] color] (com.googlecode.lanterna.terminal.TextColor$RGB. r g b))))
+
 (defn put-string
   "Put a string on the screen buffer, ready to be drawn at the next redraw.
 
@@ -172,8 +177,8 @@
    (let [styles ^clojure.lang.PersistentHashSet (set (map c/styles styles))
          x (int x)
          y (int y)
-         fg ^com.googlecode.lanterna.terminal.Terminal$Color (c/colors fg)
-         bg ^com.googlecode.lanterna.terminal.Terminal$Color (c/colors bg)]
+         fg (get-color fg)
+         bg (get-color bg)]
      (.putString screen x y s fg bg styles))))
 
 (defn put-sheet

--- a/src/lanterna/terminal.clj
+++ b/src/lanterna/terminal.clj
@@ -198,12 +198,14 @@
 (defn set-fg-color [^Terminal terminal color]
   (cond (integer? color) (.applyForegroundColor terminal color)
         (keyword? color) (.applyForegroundColor terminal (c/colors color))
-        :else (let [[r g b] color] (.applyForegroundColor terminal r g b))))
+        (vector? color) (let [[r g b] color] (.applyForegroundColor terminal r g b))
+        :else nil))
 
 (defn set-bg-color [^Terminal terminal color]
   (cond (integer? color) (.applyBackgroundColor terminal color)
         (keyword? color) (.applyBackgroundColor terminal (c/colors color))
-        :else (let [[r g b] color] (.applyBackgroundColor terminal r g b))))
+        (vector? color) (let [[r g b] color] (.applyBackgroundColor terminal r g b))
+        :else nil))
 
 ; TODO: Fix these.
 (defn set-style


### PR DESCRIPTION
Now you can add a vector of ints for an RGB, an integer or a keyword to change the colour. If you pass none of these then no match occurs and it returns `nil`.

Looking forward to more Caves of Clojure when you get the chance.

Till then, enjoy!
