### PR TITLE
Add get-cursor to screen

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojure-lanterna "0.9.4"
+(defproject org.clojars.mearnsh/clojure-lanterna "0.9.4"
   :description "A Clojure wrapper around the Lanterna terminal output library."
   :url "http://sjl.bitbucket.org/clojure-lanterna/"
   :license {:name "LGPL"}

--- a/src/lanterna/screen.clj
+++ b/src/lanterna/screen.clj
@@ -139,8 +139,20 @@
   appears in a specific place.
 
   "
-  [^Screen screen x y]
-  (.setCursorPosition screen x y))
+  ([^Screen screen x y]
+     (.setCursorPosition screen x y))
+  ([^Screen screen pos]
+     (apply #(.setCursorPosition screen %1 %2) pos)))
+
+
+(defn get-cursor
+  "Return the cursor position as [col row]."
+  [^Screen screen]
+  (let [pos (.getCursorPosition screen)
+        col (.getColumn pos)
+        row (.getRow pos)]
+    [col row]))
+
 
 (defn put-string
   "Put a string on the screen buffer, ready to be drawn at the next redraw.


### PR DESCRIPTION
get-cursor wraps .getCursorPosition. Introduce new arity for move-cursor
so position vectors returned by get-cursor can be passed to it directly.
