### PR TITLE
Correct map destructuring bug in screen.clj.

### DIFF
--- a/src/lanterna/screen.clj
+++ b/src/lanterna/screen.clj
@@ -71,10 +71,10 @@
   ([kind] (get-screen kind {}))
   ([kind {:as opts
           :keys [cols rows charset resize-listener]
-          :or {:cols 80
-               :rows 24
-               :charset :utf-8
-               :resize-listener nil}}]
+          :or {cols 80
+               rows 24
+               charset :utf-8
+               resize-listener nil}}]
    (new Screen (t/get-terminal kind opts))))
 
 


### PR DESCRIPTION
This corrects a clojure.spec violation, making it possible to use clojure-lanterna in projects with Clojure 1.9.0-alpha13.
